### PR TITLE
Restrict guest addition to accepted events

### DIFF
--- a/public/event.php
+++ b/public/event.php
@@ -29,15 +29,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_event'])) {
     exit;
 }
 
-// --- ADD GUEST(s) ---
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_guest_ids'])) {
+// --- FETCH EVENT ---
+$evt = $memPdo->prepare("SELECT * FROM events WHERE id=?");
+$evt->execute([$event_id]);
+$event = $evt->fetch(PDO::FETCH_ASSOC);
+
+// --- ADD GUEST(s) --- only when event is accepted
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    isset($_POST['add_guest_ids']) &&
+    ($event['status'] ?? '') === 'accepted'
+) {
     foreach ($_POST['add_guest_ids'] as $gid) {
-        // get invite_code for each guest
         $stmt2 = $emPdo->prepare("SELECT invite_code FROM guests WHERE id=?");
         $stmt2->execute([$gid]);
         $invite_code = $stmt2->fetchColumn();
-        $memPdo->prepare("INSERT IGNORE INTO event_guests (event_id, guest_id, invitation_code) VALUES (?, ?, ?)")
-               ->execute([$event_id, $gid, $invite_code]);
+        $memPdo
+            ->prepare(
+                "INSERT IGNORE INTO event_guests (event_id, guest_id, invitation_code) VALUES (?, ?, ?)"
+            )
+            ->execute([$event_id, $gid, $invite_code]);
     }
     header("Location: event.php?event_id=$event_id");
     exit;
@@ -51,13 +62,8 @@ if (isset($_GET['remove_guest'])) {
     exit;
 }
 
-// --- FETCH EVENT ---
-$evt = $memPdo->prepare("SELECT * FROM events WHERE id=?");
-$evt->execute([$event_id]);
-$event = $evt->fetch(PDO::FETCH_ASSOC);
-
 // --- CURRENT GUESTS ---
-$q = $memPdo->prepare("SELECT eg.*, g.name, g.email, g.invite_code FROM event_guests eg JOIN {$emDbConf['dbname']}.guests g ON eg.guest_id=g.id WHERE eg.event_id=?");
+$q = $memPdo->prepare("SELECT eg.*, g.name, g.email, g.invite_code FROM event_guests eg JOIN `{$emDbConf['dbname']}`.guests g ON eg.guest_id=g.id WHERE eg.event_id=?");
 $q->execute([$event_id]);
 $added_guests = $q->fetchAll(PDO::FETCH_ASSOC);
 
@@ -130,24 +136,28 @@ include __DIR__ . '/../templates/topbar.php';
             </table>
         </div>
 
-        <h5 class="mb-2 mt-4">Add Guests</h5>
-        <form method="post" class="mb-0">
-            <div class="row g-2">
-                <div class="col-md-8">
-                    <select name="add_guest_ids[]" class="form-select" multiple size="6" required>
-                        <?php foreach ($all as $g): ?>
-                            <option value="<?= $g['id'] ?>">
-                                <?= htmlspecialchars($g['name']) ?> (<?= htmlspecialchars($g['email']) ?>)
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
+        <?php if (($event['status'] ?? '') === 'accepted'): ?>
+            <h5 class="mb-2 mt-4">Add Guests</h5>
+            <form method="post" class="mb-0">
+                <div class="row g-2">
+                    <div class="col-md-8">
+                        <select name="add_guest_ids[]" class="form-select" multiple size="6" required>
+                            <?php foreach ($all as $g): ?>
+                                <option value="<?= $g['id'] ?>">
+                                    <?= htmlspecialchars($g['name']) ?> (<?= htmlspecialchars($g['email']) ?>)
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="col-md-4 align-self-end">
+                        <button class="btn btn-accent px-4" type="submit">Add Selected</button>
+                    </div>
                 </div>
-                <div class="col-md-4 align-self-end">
-                    <button class="btn btn-accent px-4" type="submit">Add Selected</button>
-                </div>
-            </div>
-            <small class="text-secondary mt-2 d-block">Hold Ctrl/Cmd to select multiple guests.</small>
-        </form>
+                <small class="text-secondary mt-2 d-block">Hold Ctrl/Cmd to select multiple guests.</small>
+            </form>
+        <?php else: ?>
+            <div class="alert alert-info mt-4">Event must be accepted before adding guests.</div>
+        <?php endif; ?>
     </div>
 </main>
 <?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/public/guests.php
+++ b/public/guests.php
@@ -14,18 +14,38 @@ if (!$event_id) {
 
 // DB connections
 $memDbConf = $config['db_memories'];
-$memPdo = new PDO("mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}", $memDbConf['user'], $memDbConf['pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+$memPdo = new PDO(
+    "mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}",
+    $memDbConf['user'],
+    $memDbConf['pass'],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
 $emDbConf = $config['db_event_manager'];
-$emPdo = new PDO("mysql:host={$emDbConf['host']};dbname={$emDbConf['dbname']};charset={$emDbConf['charset']}", $emDbConf['user'], $emDbConf['pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+$emPdo = new PDO(
+    "mysql:host={$emDbConf['host']};dbname={$emDbConf['dbname']};charset={$emDbConf['charset']}",
+    $emDbConf['user'],
+    $emDbConf['pass'],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
 
-// ADD GUEST(s)
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_guest_ids'])) {
+// Get event info
+$evt = $memPdo->prepare("SELECT * FROM events WHERE id=?");
+$evt->execute([$event_id]);
+$event = $evt->fetch(PDO::FETCH_ASSOC);
+
+// ADD GUEST(s) when event is accepted
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    isset($_POST['add_guest_ids']) &&
+    ($event['status'] ?? '') === 'accepted'
+) {
     foreach ($_POST['add_guest_ids'] as $gid) {
-        // Get invitation_code from event-manager
         $g = $emPdo->prepare("SELECT invitation_code FROM guests WHERE id=?");
         $g->execute([$gid]);
         $code = $g->fetchColumn();
-        $stmt = $memPdo->prepare("INSERT INTO event_guests (event_id, guest_id, invitation_code) VALUES (?, ?, ?)");
+        $stmt = $memPdo->prepare(
+            "INSERT INTO event_guests (event_id, guest_id, invitation_code) VALUES (?, ?, ?)"
+        );
         $stmt->execute([$event_id, $gid, $code]);
     }
     header("Location: guests.php?event_id=" . $event_id);
@@ -39,13 +59,9 @@ if (isset($_GET['remove_guest'])) {
     exit;
 }
 
-// Get event info (optional)
-$evt = $memPdo->prepare("SELECT * FROM events WHERE id=?");
-$evt->execute([$event_id]);
-$event = $evt->fetch(PDO::FETCH_ASSOC);
 
 // Guests already in this event:
-$q = $memPdo->prepare("SELECT eg.*, g.name, g.email, g.invitation_code FROM event_guests eg JOIN {$emDbConf['dbname']}.guests g ON eg.guest_id=g.id WHERE eg.event_id=?");
+$q = $memPdo->prepare("SELECT eg.*, g.name, g.email, g.invitation_code FROM event_guests eg JOIN `{$emDbConf['dbname']}`.guests g ON eg.guest_id=g.id WHERE eg.event_id=?");
 $q->execute([$event_id]);
 $added_guests = $q->fetchAll(PDO::FETCH_ASSOC);
 
@@ -91,24 +107,28 @@ include __DIR__ . '/../templates/topbar.php';
             </table>
         </div>
         
-        <h5 class="mb-2 mt-4">Add Guests</h5>
-        <form method="post" class="mb-0">
-            <div class="row g-2">
-                <div class="col-md-8">
-                    <select name="add_guest_ids[]" class="form-select" multiple size="6" required>
-                        <?php foreach ($all as $g): ?>
-                            <option value="<?= $g['id'] ?>">
-                                <?= htmlspecialchars($g['name']) ?> (<?= htmlspecialchars($g['email']) ?>)
-                            </option>
-                        <?php endforeach ?>
-                    </select>
+        <?php if (($event['status'] ?? '') === 'accepted'): ?>
+            <h5 class="mb-2 mt-4">Add Guests</h5>
+            <form method="post" class="mb-0">
+                <div class="row g-2">
+                    <div class="col-md-8">
+                        <select name="add_guest_ids[]" class="form-select" multiple size="6" required>
+                            <?php foreach ($all as $g): ?>
+                                <option value="<?= $g['id'] ?>">
+                                    <?= htmlspecialchars($g['name']) ?> (<?= htmlspecialchars($g['email']) ?>)
+                                </option>
+                            <?php endforeach ?>
+                        </select>
+                    </div>
+                    <div class="col-md-4 align-self-end">
+                        <button class="btn btn-accent px-4" type="submit">Add Selected</button>
+                    </div>
                 </div>
-                <div class="col-md-4 align-self-end">
-                    <button class="btn btn-accent px-4" type="submit">Add Selected</button>
-                </div>
-            </div>
-            <small class="text-secondary mt-2 d-block">Hold Ctrl/Cmd to select multiple guests.</small>
-        </form>
+                <small class="text-secondary mt-2 d-block">Hold Ctrl/Cmd to select multiple guests.</small>
+            </form>
+        <?php else: ?>
+            <div class="alert alert-info mt-4">Event must be accepted before adding guests.</div>
+        <?php endif; ?>
     </div>
 </main>
 <?php include __DIR__ . '/../templates/footer.php'; ?>


### PR DESCRIPTION
## Summary
- only allow adding guests when an event status is `accepted`
- escape database name when joining event manager tables
- hide the "Add Guests" form until an event is accepted

All `php -l public/*.php` checks pass.


------
https://chatgpt.com/codex/tasks/task_e_68813ebf42c0832e940fad9a782723b0