### PR TITLE
Enable guest editing and event status

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,10 @@ Then browse to `http://localhost:8000`.
 - `config/` – configuration samples
 - `src/` – PHP classes (currently minimal)
 
+## Event Status
+Events progress through three states: **Created**, **Started** and **Ended**. The
+status can be changed on the Edit Event page and is displayed in the events
+list.
+
 ## Development Notes
 Run `php -l public/*.php` before committing to ensure there are no syntax errors.

--- a/public/events.php
+++ b/public/events.php
@@ -18,13 +18,16 @@ $guestManager = new GuestManager($emPdo, $memPdo);
 
 // --- ADD EVENT ---
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['event_name'])) {
-    $stmt = $memPdo->prepare("INSERT INTO events (event_name, event_date, event_location, description, created_by) VALUES (?, ?, ?, ?, ?)");
+    $stmt = $memPdo->prepare(
+        "INSERT INTO events (event_name, event_date, event_location, description, created_by, status) VALUES (?, ?, ?, ?, ?, ?)"
+    );
     $stmt->execute([
         $_POST['event_name'],
         $_POST['event_date'],
         $_POST['event_location'],
         $_POST['description'],
-        $_SESSION['user_id']
+        $_SESSION['user_id'],
+        'Created'
     ]);
     $event_id = $memPdo->lastInsertId();
 
@@ -97,6 +100,7 @@ include __DIR__ . '/../templates/topbar.php';
                         <th>Date</th>
                         <th>Location</th>
                         <th>Description</th>
+                        <th>Status</th>
                         <th style="width:120px;">Action</th>
                     </tr>
                 </thead>
@@ -107,6 +111,7 @@ include __DIR__ . '/../templates/topbar.php';
                         <td><?= htmlspecialchars($event['event_date']) ?></td>
                         <td><?= htmlspecialchars($event['event_location']) ?></td>
                         <td><?= htmlspecialchars($event['description']) ?></td>
+                        <td><?= htmlspecialchars($event['status'] ?? '') ?></td>
                         <td>
                             <a href="event.php?event_id=<?= $event['id'] ?>" class="btn btn-accent btn-sm">Edit</a>
                             <a href="events.php?delete=<?= $event['id'] ?>" class="btn btn-danger btn-sm" onclick="return confirm('Delete this event?')"><i class="bi bi-trash"></i></a>

--- a/public/guests.php
+++ b/public/guests.php
@@ -34,11 +34,10 @@ $evt->execute([$event_id]);
 $event = $evt->fetch(PDO::FETCH_ASSOC);
 
 
-// ADD GUEST(s) when event is accepted
+// ADD GUEST(s)
 if (
     $_SERVER['REQUEST_METHOD'] === 'POST' &&
-    isset($_POST['add_guest_ids']) &&
-    ($event['status'] ?? '') === 'accepted'
+    isset($_POST['add_guest_ids'])
 ) {
     foreach ($_POST['add_guest_ids'] as $gid) {
         $g = $emPdo->prepare("SELECT invitation_code FROM guests WHERE id=?");


### PR DESCRIPTION
## Summary
- allow updating event status and always add guests
- show status in event list and default to "Created" when creating events
- remove old acceptance checks for guest management
- document event status states

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_6881582e4dac832e8d24eb46da95fcc3