### PR TITLE
Fix header image removed when editing event

### DIFF
--- a/public/event.php
+++ b/public/event.php
@@ -18,6 +18,11 @@ $memPdo = new PDO("mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']}
 $emDbConf = $config['db_event_manager'];
 $emPdo = new PDO("mysql:host={$emDbConf['host']};dbname={$emDbConf['dbname']};charset={$emDbConf['charset']}", $emDbConf['user'], $emDbConf['pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
+// --- FETCH EVENT ---
+$evt = $memPdo->prepare("SELECT * FROM events WHERE id=?");
+$evt->execute([$event_id]);
+$event = $evt->fetch(PDO::FETCH_ASSOC);
+
 // --- UPDATE EVENT DETAILS ---
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_event'])) {
     $uploader = new UploadManager($config['do_spaces']);
@@ -40,11 +45,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_event'])) {
     header("Location: event.php?event_id=$event_id&updated=1");
     exit;
 }
-
-// --- FETCH EVENT ---
-$evt = $memPdo->prepare("SELECT * FROM events WHERE id=?");
-$evt->execute([$event_id]);
-$event = $evt->fetch(PDO::FETCH_ASSOC);
 
 // --- ADD GUEST(s) --- always allowed
 if (


### PR DESCRIPTION
## Summary
- fetch event before update in `public/event.php` so the existing header image value is available
- ran `php -l` on all public PHP files

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_68815e70c9e4832eaa414f8910d9152c