### PR TITLE
Add public event links and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A simple PHP application for managing events and guests. This project is a small
 1. Copy `config/config-example.php` to `config/config.php` and adjust the database credentials and DigitalOcean Spaces information.
 2. Run `composer install` to fetch the AWS SDK used for uploading images to DigitalOcean Spaces.
 3. Make sure the required MySQL databases exist and the credentials match your setup.
-4. The guest selector relies on the Choices.js library loaded from a CDN. Ensure the host running the app can access the CDN or adjust the paths accordingly.
+4. Run the SQL in `sql/alter_add_public_id.sql` to add the `public_id` column used for public event links.
+5. The guest selector relies on the Choices.js library loaded from a CDN. Ensure the host running the app can access the CDN or adjust the paths accordingly.
 
 ## Running
 Use PHP's built-in server from the project root:

--- a/public/event.php
+++ b/public/event.php
@@ -127,6 +127,10 @@ include __DIR__ . '/../templates/topbar.php';
                     <label class="form-label">Location</label>
                     <input type="text" name="event_location" class="form-control" value="<?= htmlspecialchars($event['event_location']) ?>">
                 </div>
+                <div class="col-12 col-md-6">
+                    <label class="form-label">Public URL</label>
+                    <input type="text" readonly class="form-control" value="<?= htmlspecialchars((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . '/e/' . $event['public_id']) ?>">
+                </div>
                 <div class="col-12 col-md-5">
                     <label class="form-label">Header Image</label>
                     <?php if (!empty($event['header_image'])): ?>

--- a/public/event_public.php
+++ b/public/event_public.php
@@ -1,0 +1,41 @@
+<?php
+$config = require __DIR__ . '/../config/config.php';
+
+$publicId = $_GET['public_id'] ?? '';
+if ($publicId === '') {
+    http_response_code(404);
+    echo 'Event not found';
+    exit;
+}
+
+$memDbConf = $config['db_memories'];
+$memPdo = new PDO(
+    "mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}",
+    $memDbConf['user'],
+    $memDbConf['pass'],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+
+$stmt = $memPdo->prepare('SELECT * FROM events WHERE public_id = ? LIMIT 1');
+$stmt->execute([$publicId]);
+$event = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$event) {
+    http_response_code(404);
+    echo 'Event not found';
+    exit;
+}
+
+$page_title = $event['event_name'];
+include __DIR__ . '/../templates/header.php';
+?>
+<main class="container py-5">
+    <h1 class="mb-3 text-center"><?= htmlspecialchars($event['event_name']) ?></h1>
+    <?php if (!empty($event['header_image'])): ?>
+        <img src="<?= htmlspecialchars($event['header_image']) ?>" class="img-fluid mb-3" alt="header">
+    <?php endif; ?>
+    <p><strong>Date:</strong> <?= htmlspecialchars($event['event_date']) ?></p>
+    <p><strong>Location:</strong> <?= htmlspecialchars($event['event_location']) ?></p>
+    <p><?= nl2br(htmlspecialchars($event['description'])) ?></p>
+</main>
+<?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/public/events.php
+++ b/public/events.php
@@ -25,10 +25,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['event_name'])) {
     if (isset($_FILES['header_image']) && is_uploaded_file($_FILES['header_image']['tmp_name'])) {
         $headerImage = $uploader->upload($_FILES['header_image']['tmp_name'], $_FILES['header_image']['name']);
     }
+    $publicId = bin2hex(random_bytes(8));
     $stmt = $memPdo->prepare(
-        "INSERT INTO events (event_name, event_date, event_location, description, created_by, status, header_image) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO events (public_id, event_name, event_date, event_location, description, created_by, status, header_image) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
     );
     $stmt->execute([
+        $publicId,
         $_POST['event_name'],
         $_POST['event_date'],
         $_POST['event_location'],

--- a/public/find_event.php
+++ b/public/find_event.php
@@ -1,0 +1,52 @@
+<?php
+$config = require __DIR__ . '/../config/config.php';
+
+$memDbConf = $config['db_memories'];
+$memPdo = new PDO(
+    "mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}",
+    $memDbConf['user'],
+    $memDbConf['pass'],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+
+$error = '';
+$event = null;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $code = trim($_POST['invite_code'] ?? '');
+    if ($code === '') {
+        $error = 'Enter invite code';
+    } else {
+        $stmt = $memPdo->prepare('SELECT e.* FROM event_guests eg JOIN events e ON eg.event_id = e.id WHERE eg.invitation_code = ? LIMIT 1');
+        $stmt->execute([$code]);
+        $event = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$event) {
+            $error = 'Invite code not found';
+        }
+    }
+}
+
+$page_title = 'Find Event';
+include __DIR__ . '/../templates/header.php';
+?>
+<main class="container py-5" style="max-width:420px;">
+    <h1 class="mb-3 text-center">Find Your Event</h1>
+    <form method="post" class="mb-4">
+        <div class="mb-3">
+            <label class="form-label">Invite Code</label>
+            <input type="text" name="invite_code" class="form-control" required>
+        </div>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+        <button type="submit" class="btn btn-accent w-100">Search</button>
+    </form>
+    <?php if ($event): ?>
+        <div class="card p-3" style="background: var(--card-bg);">
+            <h5><?= htmlspecialchars($event['event_name']) ?></h5>
+            <p class="mb-1"><strong>Date:</strong> <?= htmlspecialchars($event['event_date']) ?></p>
+            <p class="mb-2"><strong>Location:</strong> <?= htmlspecialchars($event['event_location']) ?></p>
+            <a href="/e/<?= urlencode($event['public_id']) ?>" class="btn btn-accent">Open Event Page</a>
+        </div>
+    <?php endif; ?>
+</main>
+<?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -13,9 +13,22 @@ switch ($path) {
         require 'logout.php'; break;
     case 'guest_portal':
         require 'guest_portal.php'; break;
-	case 'guests':
+    case 'guests':
         require 'guests.php'; break;
+    case 'find_event':
+        require 'find_event.php'; break;
     default:
-        http_response_code(404);
-        echo "404 Not Found";
+        // handled below
+        break;
+}
+
+if (preg_match('#^e/([A-Za-z0-9]+)$#', $path, $m)) {
+    $_GET['public_id'] = $m[1];
+    require 'event_public.php';
+    return;
+}
+
+if ($path !== '' && !in_array($path, ['dashboard','events','login','logout','guest_portal','guests','find_event'])) {
+    http_response_code(404);
+    echo "404 Not Found";
 }

--- a/sql/alter_add_public_id.sql
+++ b/sql/alter_add_public_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE events
+    ADD COLUMN public_id VARCHAR(32) NOT NULL UNIQUE AFTER id;


### PR DESCRIPTION
## Summary
- add `public_id` column for events
- generate public IDs when creating events
- show event public URL on edit page
- add a public event page and find-event page
- update router and docs

## Testing
- `php -l public/dashboard.php`
- `php -l public/event.php`
- `php -l public/events.php`
- `php -l public/find_event.php`
- `php -l public/event_public.php`
- `php -l public/guest_search.php`
- `php -l public/index.php`
- `php -l public/login.php`
- `php -l public/logout.php`
- `php -l public/guests.php`
- `php -l public/guest_portal.php`


------
https://chatgpt.com/codex/tasks/task_e_68815fec0538832eb865148d183c08be