### PR TITLE
Add QR codes and regenerate public id

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple PHP application for managing events and guests. This project is a small
 
 ## Setup
 1. Copy `config/config-example.php` to `config/config.php` and adjust the database credentials and DigitalOcean Spaces information.
-2. Run `composer install` to fetch the AWS SDK used for uploading images to DigitalOcean Spaces.
+2. Run `composer install` to fetch required PHP dependencies such as the AWS SDK and QR code library.
 3. Make sure the required MySQL databases exist and the credentials match your setup.
 4. Run the SQL in `sql/alter_add_public_id.sql` to add the `public_id` column used for public event links.
 5. The guest selector relies on the Choices.js library loaded from a CDN. Ensure the host running the app can access the CDN or adjust the paths accordingly.
@@ -29,6 +29,9 @@ list.
 
 ## Event Header Images
 You can upload an optional header image when creating or editing an event. Images are uploaded to your configured DigitalOcean Spaces bucket.
+
+## Event QR Codes
+Each event page shows a QR code linking to the public event URL. You can regenerate the event's public identifier from the Edit Event screen which will update the QR code accordingly.
 
 ## Development Notes
 Run `php -l public/*.php` before committing to ensure there are no syntax errors.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "aws/aws-sdk-php": "^3.351"
+        "aws/aws-sdk-php": "^3.351",
+        "endroid/qr-code": "~5.0"
     }
 }

--- a/public/event.php
+++ b/public/event.php
@@ -23,6 +23,14 @@ $evt = $memPdo->prepare("SELECT * FROM events WHERE id=?");
 $evt->execute([$event_id]);
 $event = $evt->fetch(PDO::FETCH_ASSOC);
 
+// --- Regenerate Public ID ---
+if (isset($_GET['regen_public_id'])) {
+    $newId = bin2hex(random_bytes(8));
+    $memPdo->prepare("UPDATE events SET public_id=? WHERE id=?")
+        ->execute([$newId, $event_id]);
+    $event['public_id'] = $newId;
+}
+
 // --- UPDATE EVENT DETAILS ---
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_event'])) {
     $uploader = new UploadManager($config['do_spaces']);
@@ -129,7 +137,11 @@ include __DIR__ . '/../templates/topbar.php';
                 </div>
                 <div class="col-12 col-md-6">
                     <label class="form-label">Public URL</label>
-                    <input type="text" readonly class="form-control" value="<?= htmlspecialchars((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . '/e/' . $event['public_id']) ?>">
+                    <div class="input-group">
+                        <input type="text" readonly class="form-control" value="<?= htmlspecialchars((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . '/e/' . $event['public_id']) ?>">
+                        <a href="?event_id=<?= $event_id ?>&regen_public_id=1" class="btn btn-outline-secondary">Regenerate</a>
+                    </div>
+                    <img src="qr.php?public_id=<?= urlencode($event['public_id']) ?>" alt="QR" width="150" height="150" class="mt-2">
                 </div>
                 <div class="col-12 col-md-5">
                     <label class="form-label">Header Image</label>

--- a/public/qr.php
+++ b/public/qr.php
@@ -1,0 +1,28 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+$config = require __DIR__ . '/../config/config.php';
+
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\PngWriter;
+
+$publicId = $_GET['public_id'] ?? '';
+if ($publicId === '') {
+    http_response_code(404);
+    echo 'Public ID missing';
+    exit;
+}
+
+$url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http')
+    . '://' . $_SERVER['HTTP_HOST'] . '/e/' . $publicId;
+
+$qrCode = QrCode::create($url)
+    ->setSize(300)
+    ->setMargin(10);
+
+$writer = new PngWriter();
+$result = $writer->write($qrCode);
+
+header('Content-Type: ' . $result->getMimeType());
+
+echo $result->getString();
+


### PR DESCRIPTION
## Summary
- allow regenerating event public id
- show QR code for event link
- generate QR code images via new endpoint
- include endroid/qr-code in composer dependencies
- document QR code feature and updated setup steps

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_688163c189a0832eb2384879d86d8e4c