### PR TITLE
Improve event pages and add custom CSS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A simple PHP application for managing events and guests. This project is a small
 2. Run `composer install` to fetch required PHP dependencies such as the AWS SDK and QR code library.
 3. Make sure the required MySQL databases exist and the credentials match your setup.
 4. Run the SQL in `sql/alter_add_public_id.sql` to add the `public_id` column used for public event links.
-5. The guest selector relies on the Choices.js library loaded from a CDN. Ensure the host running the app can access the CDN or adjust the paths accordingly.
+5. Run `sql/alter_add_header_image.sql` and `sql/alter_add_custom_css.sql` if upgrading from an older database.
+6. The guest selector relies on the Choices.js library loaded from a CDN. Ensure the host running the app can access the CDN or adjust the paths accordingly.
 
 ## Running
 Use PHP's built-in server from the project root:

--- a/public/event.php
+++ b/public/event.php
@@ -39,7 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_event'])) {
         $headerImage = $uploader->upload($_FILES['header_image']['tmp_name'], $_FILES['header_image']['name']);
     }
     $stmt = $memPdo->prepare(
-        "UPDATE events SET event_name=?, event_date=?, event_location=?, description=?, status=?, header_image=? WHERE id=?"
+        "UPDATE events SET event_name=?, event_date=?, event_location=?, description=?, status=?, header_image=?, custom_css=? WHERE id=?"
     );
     $stmt->execute([
         $_POST['event_name'],
@@ -48,6 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_event'])) {
         $_POST['description'],
         $_POST['status'],
         $headerImage,
+        $_POST['custom_css'] ?? null,
         $event_id
     ]);
     header("Location: event.php?event_id=$event_id&updated=1");
@@ -153,6 +154,10 @@ include __DIR__ . '/../templates/topbar.php';
                 <div class="col-12">
                     <label class="form-label">Description</label>
                     <textarea name="description" rows="2" class="form-control"><?= htmlspecialchars($event['description']) ?></textarea>
+                </div>
+                <div class="col-12">
+                    <label class="form-label">Custom CSS</label>
+                    <textarea name="custom_css" rows="4" class="form-control" placeholder="Optional CSS overrides"><?= htmlspecialchars($event['custom_css'] ?? '') ?></textarea>
                 </div>
                 <div class="col-md-3">
                     <label class="form-label">Status</label>

--- a/public/event_public.php
+++ b/public/event_public.php
@@ -29,13 +29,18 @@ if (!$event) {
 $page_title = $event['event_name'];
 include __DIR__ . '/../templates/header.php';
 ?>
-<main class="container py-5">
-    <h1 class="mb-3 text-center"><?= htmlspecialchars($event['event_name']) ?></h1>
-    <?php if (!empty($event['header_image'])): ?>
-        <img src="<?= htmlspecialchars($event['header_image']) ?>" class="img-fluid mb-3" alt="header">
-    <?php endif; ?>
-    <p><strong>Date:</strong> <?= htmlspecialchars($event['event_date']) ?></p>
-    <p><strong>Location:</strong> <?= htmlspecialchars($event['event_location']) ?></p>
-    <p><?= nl2br(htmlspecialchars($event['description'])) ?></p>
+<?php if (!empty($event['custom_css'])): ?>
+    <style><?= $event['custom_css'] ?></style>
+<?php endif; ?>
+<main class="d-flex align-items-center justify-content-center" style="min-height:100vh;">
+    <div class="p-4" style="background: var(--card-bg); border-radius: var(--border-radius); max-width:720px; width:100%;">
+        <?php if (!empty($event['header_image'])): ?>
+            <img src="<?= htmlspecialchars($event['header_image']) ?>" class="img-fluid mb-3" alt="header" style="border-radius:var(--border-radius);">
+        <?php endif; ?>
+        <h1 class="mb-3 text-center"><?= htmlspecialchars($event['event_name']) ?></h1>
+        <p><strong>Date:</strong> <?= htmlspecialchars($event['event_date']) ?></p>
+        <p><strong>Location:</strong> <?= htmlspecialchars($event['event_location']) ?></p>
+        <p><?= nl2br(htmlspecialchars($event['description'])) ?></p>
+    </div>
 </main>
 <?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/public/events.php
+++ b/public/events.php
@@ -27,7 +27,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['event_name'])) {
     }
     $publicId = bin2hex(random_bytes(8));
     $stmt = $memPdo->prepare(
-        "INSERT INTO events (public_id, event_name, event_date, event_location, description, created_by, status, header_image) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO events (public_id, event_name, event_date, event_location, description, created_by, status, header_image, custom_css) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     $stmt->execute([
         $publicId,
@@ -37,7 +37,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['event_name'])) {
         $_POST['description'],
         $_SESSION['user_id'],
         'Created',
-        $headerImage
+        $headerImage,
+        null
     ]);
     $event_id = $memPdo->lastInsertId();
 

--- a/public/find_event.php
+++ b/public/find_event.php
@@ -28,25 +28,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $page_title = 'Find Event';
 include __DIR__ . '/../templates/header.php';
 ?>
-<main class="container py-5" style="max-width:420px;">
-    <h1 class="mb-3 text-center">Find Your Event</h1>
-    <form method="post" class="mb-4">
-        <div class="mb-3">
-            <label class="form-label">Invite Code</label>
-            <input type="text" name="invite_code" class="form-control" required>
-        </div>
-        <?php if ($error): ?>
-            <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+<div class="d-flex align-items-center justify-content-center" style="min-height:100vh;">
+    <div class="p-4" style="background: var(--card-bg); border-radius: var(--border-radius); box-shadow: 0 4px 24px #0001; max-width:420px; width:100%;">
+        <h2 class="mb-3 text-center">Find Your Event</h2>
+        <form method="post" class="mb-4">
+            <div class="mb-3">
+                <label class="form-label">Invite Code</label>
+                <input type="text" name="invite_code" class="form-control" required>
+            </div>
+            <?php if ($error): ?>
+                <div class="alert alert-danger py-2 text-center mb-3"><?= htmlspecialchars($error) ?></div>
+            <?php endif; ?>
+            <button type="submit" class="btn btn-accent w-100">Search</button>
+        </form>
+        <?php if ($event): ?>
+            <div class="card p-3" style="background: var(--sidebar-bg);">
+                <h5><?= htmlspecialchars($event['event_name']) ?></h5>
+                <p class="mb-1"><strong>Date:</strong> <?= htmlspecialchars($event['event_date']) ?></p>
+                <p class="mb-2"><strong>Location:</strong> <?= htmlspecialchars($event['event_location']) ?></p>
+                <a href="/e/<?= urlencode($event['public_id']) ?>" class="btn btn-accent">Open Event Page</a>
+            </div>
         <?php endif; ?>
-        <button type="submit" class="btn btn-accent w-100">Search</button>
-    </form>
-    <?php if ($event): ?>
-        <div class="card p-3" style="background: var(--card-bg);">
-            <h5><?= htmlspecialchars($event['event_name']) ?></h5>
-            <p class="mb-1"><strong>Date:</strong> <?= htmlspecialchars($event['event_date']) ?></p>
-            <p class="mb-2"><strong>Location:</strong> <?= htmlspecialchars($event['event_location']) ?></p>
-            <a href="/e/<?= urlencode($event['public_id']) ?>" class="btn btn-accent">Open Event Page</a>
-        </div>
-    <?php endif; ?>
-</main>
+    </div>
+</div>
 <?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/sql/alter_add_custom_css.sql
+++ b/sql/alter_add_custom_css.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN custom_css TEXT DEFAULT NULL;


### PR DESCRIPTION
## Summary
- restyle `find_event.php` to match the theme
- modernize `event_public.php` and allow per-event CSS overrides
- store custom CSS for events and expose field on the edit page
- support new column when creating events
- document DB upgrade step

All `php -l public/*.php` checks pass.


------
https://chatgpt.com/codex/tasks/task_e_688169934a28832ea0f0ab5d5c5597f0