### PR TITLE
Create upload folders for new events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A simple PHP application for managing events and guests. This project is a small
 2. Run `composer install` to fetch required PHP dependencies such as the AWS SDK and QR code library.
 3. Make sure the required MySQL databases exist and the credentials match your setup.
 4. Run the SQL in `sql/alter_add_public_id.sql` to add the `public_id` column used for public event links.
-5. The guest selector relies on the Choices.js library loaded from a CDN. Ensure the host running the app can access the CDN or adjust the paths accordingly.
+5. Run the SQL in `sql/alter_add_upload_folder.sql` to add the `upload_folder` column storing each event's DigitalOcean folder path.
+6. The guest selector relies on the Choices.js library loaded from a CDN. Ensure the host running the app can access the CDN or adjust the paths accordingly.
 
 ## Running
 Use PHP's built-in server from the project root:

--- a/public/events.php
+++ b/public/events.php
@@ -41,6 +41,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['event_name'])) {
     ]);
     $event_id = $memPdo->lastInsertId();
 
+    // create DO folder for uploads
+    $folder = 'events/' . $event_id;
+    $uploader->createFolder($folder);
+    $memPdo->prepare("UPDATE events SET upload_folder=? WHERE id=?")
+        ->execute([$folder . '/', $event_id]);
+
     // --- Add selected guests (if any) ---
     if (!empty($_POST['guest_ids'])) {
         $guestIds = array_map('intval', (array)$_POST['guest_ids']);

--- a/sql/alter_add_upload_folder.sql
+++ b/sql/alter_add_upload_folder.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN upload_folder VARCHAR(255) DEFAULT NULL;

--- a/src/memories/UploadManager.php
+++ b/src/memories/UploadManager.php
@@ -24,6 +24,19 @@ class UploadManager
         $this->cdnUrl = rtrim($conf['cdn_url'] ?? '', '/');
     }
 
+    /**
+     * Create an empty folder in the bucket.
+     */
+    public function createFolder(string $folder): void
+    {
+        $folder = rtrim($this->folder . $folder, '/') . '/';
+        $this->client->putObject([
+            'Bucket' => $this->bucket,
+            'Key'    => $folder,
+            'Body'   => ''
+        ]);
+    }
+
     public function upload(string $path, string $filename): string
     {
         $key = $this->folder . uniqid('event_', true) . '_' . basename($filename);


### PR DESCRIPTION
## Summary
- create `upload_folder` column SQL script
- create helper to make folders in UploadManager
- create a DigitalOcean folder when adding a new event
- document setup step for the new column

All `php -l public/*.php` checks pass.


------
https://chatgpt.com/codex/tasks/task_e_68816acaf500832eaf95b5fbb18d66b0