### PR TITLE
Add staff uploads page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,8 @@ You can upload an optional header image when creating or editing an event. Image
 ## Event QR Codes
 Each event page shows a QR code linking to the public event URL. You can regenerate the event's public identifier from the Edit Event screen which will update the QR code accordingly.
 
+## Uploads Management
+Staff users can browse all uploaded memories on the **Uploads** page in the dashboard. Choose an event from the drop-down to see its files and download or delete them. No extra setup is required beyond the feed tables mentioned above.
+
 ## Development Notes
 Run `php -l public/*.php` before committing to ensure there are no syntax errors.

--- a/public/index.php
+++ b/public/index.php
@@ -15,6 +15,8 @@ switch ($path) {
         require 'guest_portal.php'; break;
     case 'guests':
         require 'guests.php'; break;
+    case 'uploads':
+        require 'uploads.php'; break;
     case 'find_event':
         require 'find_event.php'; break;
     default:

--- a/public/uploads.php
+++ b/public/uploads.php
@@ -1,0 +1,86 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login');
+    exit;
+}
+$config = require __DIR__ . '/../config/config.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+$memDbConf = $config['db_memories'];
+$memPdo = new PDO(
+    "mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}",
+    $memDbConf['user'],
+    $memDbConf['pass'],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+
+// Fetch events for dropdown
+$events = $memPdo->query("SELECT id, event_name FROM events ORDER BY event_date DESC")
+    ->fetchAll(PDO::FETCH_ASSOC);
+$eventId = isset($_GET['event_id']) ? intval($_GET['event_id']) : ($events[0]['id'] ?? 0);
+
+// Handle delete
+if (isset($_GET['delete'])) {
+    $pid = intval($_GET['delete']);
+    $memPdo->prepare('DELETE FROM post_comments WHERE post_id=?')->execute([$pid]);
+    $memPdo->prepare('DELETE FROM post_likes WHERE post_id=?')->execute([$pid]);
+    $memPdo->prepare('DELETE FROM event_posts WHERE id=?')->execute([$pid]);
+    header('Location: uploads.php?event_id=' . $eventId);
+    exit;
+}
+
+$posts = [];
+if ($eventId) {
+    $stmt = $memPdo->prepare('SELECT * FROM event_posts WHERE event_id=? ORDER BY created_at DESC');
+    $stmt->execute([$eventId]);
+    $posts = $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$page_title = 'Uploads';
+$is_staff = true;
+$display_name = $_SESSION['display_name'] ?? $_SESSION['username'] ?? '';
+include __DIR__ . '/../templates/header.php';
+include __DIR__ . '/../templates/sidebar.php';
+include __DIR__ . '/../templates/topbar.php';
+?>
+<main class="dashboard-main">
+    <div class="dashboard-section mb-4">
+        <h2 class="mb-3 section-title">Uploads</h2>
+        <form method="get" class="mb-3">
+            <select name="event_id" class="form-select" style="max-width:240px;display:inline-block" onchange="this.form.submit()">
+                <?php foreach ($events as $e): ?>
+                    <option value="<?= $e['id'] ?>"<?= $e['id'] == $eventId ? ' selected' : '' ?>>
+                        <?= htmlspecialchars($e['event_name']) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </form>
+        <div class="table-responsive" style="border-radius:var(--border-radius);overflow:hidden;">
+            <table class="table table-dark table-hover align-middle mb-0" style="background: var(--card-bg); min-width:600px;">
+                <thead style="background: var(--sidebar-bg)">
+                    <tr>
+                        <th>File</th>
+                        <th>Uploaded By</th>
+                        <th>Uploaded At</th>
+                        <th style="width:120px;">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($posts as $p): ?>
+                    <tr>
+                        <td><a href="<?= htmlspecialchars($p['file_url']) ?>" target="_blank">Download</a></td>
+                        <td><?= htmlspecialchars($p['session_id']) ?></td>
+                        <td><?= htmlspecialchars($p['created_at']) ?></td>
+                        <td>
+                            <a href="<?= htmlspecialchars($p['file_url']) ?>" class="btn btn-secondary btn-sm" download>Download</a>
+                            <a href="?event_id=<?= $eventId ?>&delete=<?= $p['id'] ?>" class="btn btn-danger btn-sm" onclick="return confirm('Delete this upload?')"><i class="bi bi-trash"></i></a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</main>
+<?php include __DIR__ . '/../templates/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add new staff page to browse uploads per event
- route `/uploads` in index
- document uploads page in README

All lint checks pass (`php -l public/*.php`).

------
https://chatgpt.com/codex/tasks/task_e_68818f2b953c832ead208b92f149d8de