### PR TITLE
Handle failed video conversions

### DIFF
--- a/src/memories/MediaProcessor.php
+++ b/src/memories/MediaProcessor.php
@@ -28,9 +28,10 @@ class MediaProcessor
         }
         if ($this->isVideo($dest)) {
             $processed = $eventDir . '/' . $base . '.mp4';
-            $this->processVideo($dest, $processed);
-            unlink($dest);
-            $dest = $processed;
+            if ($this->processVideo($dest, $processed)) {
+                unlink($dest);
+                $dest = $processed;
+            }
         } elseif ($this->isImage($dest)) {
             $this->processImage($dest);
         }
@@ -53,7 +54,7 @@ class MediaProcessor
         return in_array($ext, $img, true);
     }
 
-    private function processVideo(string $input, string $output): void
+    private function processVideo(string $input, string $output): bool
     {
         $cmd = sprintf(
             'ffmpeg -i %s -vf scale=1280:-2 -c:v libx264 -preset veryfast -crf 23 -c:a aac -y %s 2>&1',
@@ -61,6 +62,7 @@ class MediaProcessor
             escapeshellarg($output)
         );
         shell_exec($cmd);
+        return is_file($output);
     }
 
     private function processImage(string $path): void


### PR DESCRIPTION
## Summary
- ensure video conversion success before deleting original
- return boolean from `processVideo`

All `php -l` checks pass.


------
https://chatgpt.com/codex/tasks/task_e_6881fea3c55c832e8d5d61a654e52552