### PR TITLE
Fix upload directory creation for MediaProcessor

### DIFF
--- a/src/memories/MediaProcessor.php
+++ b/src/memories/MediaProcessor.php
@@ -3,12 +3,12 @@
 class MediaProcessor
 {
     private UploadManager $uploader;
-    private string $stagingDir;
+    private string $uploadDir;
 
-    public function __construct(UploadManager $uploader, string $stagingDir)
+    public function __construct(UploadManager $uploader, string $uploadDir)
     {
         $this->uploader = $uploader;
-        $this->stagingDir = rtrim($stagingDir, '/');
+        $this->uploadDir = rtrim($uploadDir, '/');
     }
 
     public function processAndUpload(int $eventId, string $uploadFolder, array $file, string $sessionId): ?string
@@ -17,9 +17,9 @@ class MediaProcessor
             return null;
         }
         $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
-        $eventDir = $this->stagingDir . '/event_' . $eventId;
+        $eventDir = $this->uploadDir . '/event_' . $eventId;
         if (!is_dir($eventDir)) {
-            mkdir($eventDir, 0777, true);
+            mkdir($eventDir, 0775, true);
         }
         $base = uniqid($sessionId . '_', true);
         $dest = $eventDir . '/' . $base . '.' . $ext;


### PR DESCRIPTION
## Summary
- rename `$stagingDir` to `$uploadDir` in `MediaProcessor`
- ensure event upload folder exists using `mkdir($eventDir, 0775, true)`

All `php -l public/*.php` lint checks pass.


------
https://chatgpt.com/codex/tasks/task_e_688201e75b60832ea81822211b862446