### PR TITLE
Add likes and camera upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A simple PHP application for managing events and guests. This project is a small
 
 7. The guest selector relies on the Choices.js library loaded from a CDN. Ensure the host running the app can access the CDN or adjust the paths accordingly.
 8. The public event page uses JavaScript and AJAX for posting memories, comments and likes. No additional setup is required but JavaScript must be enabled in the browser.
-9. Create an `uploads` directory in the project root, make it writable and ensure FFmpeg is installed for video processing.
+9. When uploading a new memory you can choose to capture media from your phone's camera or select an existing file. This works out of the box and requires no server changes.
+10. Create an `uploads` directory in the project root, make it writable and ensure FFmpeg is installed for video processing.
 
 ## Running
 Use PHP's built-in server from the project root:

--- a/public/event_public.php
+++ b/public/event_public.php
@@ -43,7 +43,12 @@ $memPdo = new PDO(
 $stmt = $memPdo->prepare('SELECT * FROM events WHERE public_id = ? LIMIT 1');
 $stmt->execute([$publicId]);
 $event = $stmt->fetch(PDO::FETCH_ASSOC);
-$eventId = $event['id'] ?? 0;
+if (!$event) {
+    http_response_code(404);
+    echo 'Event not found';
+    exit;
+}
+$eventId = $event['id'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['new_post'])) {
     $uploadOk = false;

--- a/public/views/event_public_redesign.php
+++ b/public/views/event_public_redesign.php
@@ -52,6 +52,10 @@
       width: 100%;
       border-radius: 12px;
     }
+    .like-btn.active {
+      background-color: #0d6efd;
+      color: #fff;
+    }
   </style>
 </head>
 <body>
@@ -72,7 +76,11 @@
     <div class="glass-box">
       <form method="post" enctype="multipart/form-data" id="postForm">
         <input type="hidden" name="new_post" value="1">
-        <input type="file" name="media" class="form-control mb-2" accept="image/*,video/*" required>
+        <input type="file" name="media" id="mediaInput" accept="image/*,video/*" class="d-none" required>
+        <div class="d-flex gap-2 mb-2">
+          <button type="button" class="btn btn-secondary flex-fill" id="cameraBtn">Use Camera</button>
+          <button type="button" class="btn btn-secondary flex-fill" id="uploadBtn">Choose File</button>
+        </div>
         <textarea name="caption" class="form-control mb-2" placeholder="Write a message..."></textarea>
         <button type="submit" class="btn btn-primary w-100">Upload</button>
       </form>
@@ -88,11 +96,42 @@
           <img src="<?= htmlspecialchars($p['file_url']) ?>" alt="Memory">
         <?php endif; ?>
         <?php if (!empty($p['caption'])): ?><p><?= htmlspecialchars($p['caption']) ?></p><?php endif; ?>
+        <div class="d-flex align-items-center like-container mt-1">
+          <button type="button" class="btn btn-sm btn-outline-light like-btn<?= $p['liked'] ? ' active' : '' ?>" data-post="<?= $p['id'] ?>">
+            <span class="like-text"><?= $p['liked'] ? 'Unlike' : 'Like' ?></span>
+          </button>
+          <span class="ms-2 like-count"><?= $p['likes'] ?></span>
+        </div>
       </div>
       <?php endforeach; ?>
     </div>
   </div>
 
   <button class="btn btn-light upload-btn" onclick="document.querySelector('[name=media]').click()">Add Memory</button>
+
+  <script>
+    const input = document.getElementById('mediaInput');
+    document.getElementById('cameraBtn').addEventListener('click', () => {
+      input.setAttribute('capture', 'environment');
+      input.click();
+    });
+    document.getElementById('uploadBtn').addEventListener('click', () => {
+      input.removeAttribute('capture');
+      input.click();
+    });
+    document.querySelectorAll('.like-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.post;
+        const form = new URLSearchParams({like_post: 1, post_id: id});
+        fetch('', {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}, body: form})
+          .then(r => r.json())
+          .then(d => {
+            btn.classList.toggle('active', d.liked);
+            btn.querySelector('.like-text').textContent = d.liked ? 'Unlike' : 'Like';
+            btn.closest('.like-container').querySelector('.like-count').textContent = d.likes;
+          });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix missing event error handling in `event_public.php`
- allow camera capture or file selection when uploading
- show like counts with toggle button and AJAX
- document new camera option in README

All `php -l` lint checks pass.


------
https://chatgpt.com/codex/tasks/task_e_688236cd4258832ebaec09af8d6a3e2e