### PR TITLE
Add mobile camera support and translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ Staff users can browse all uploaded memories on the **Uploads** page in the dash
 
 ## Development Notes
 Run `php -l public/*.php` before committing to ensure there are no syntax errors.
+
+## Language Support
+The event management pages (events.php and event.php) now support a simple
+translation system. Append `?lang=es` to the URL to switch to Spanish. If no
+language is provided the interface defaults to English.

--- a/public/event.php
+++ b/public/event.php
@@ -8,6 +8,7 @@ $config = require __DIR__ . '/../config/config.php';
 require __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../src/guests/guest_helpers.php';
 require_once __DIR__ . '/../src/memories/UploadManager.php';
+require_once __DIR__ . '/../src/Translation.php';
 
 $event_id = isset($_GET['event_id']) ? intval($_GET['event_id']) : 0;
 if (!$event_id) die("Event ID missing!");
@@ -17,6 +18,7 @@ $memDbConf = $config['db_memories'];
 $memPdo = new PDO("mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}", $memDbConf['user'], $memDbConf['pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 $emDbConf = $config['db_event_manager'];
 $emPdo = new PDO("mysql:host={$emDbConf['host']};dbname={$emDbConf['dbname']};charset={$emDbConf['charset']}", $emDbConf['user'], $emDbConf['pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+$tr = new Translation();
 
 // --- FETCH EVENT ---
 $evt = $memPdo->prepare("SELECT * FROM events WHERE id=?");
@@ -120,7 +122,7 @@ $already_ids = $already ? implode(',', $already) : '0';
 $all = $emPdo->query("SELECT id, name, email, invite_code FROM guests WHERE id NOT IN ($already_ids) AND rsvp_status='Accepted' ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
 
 // --- Theming Stuff ---
-$page_title = "Edit Event";
+$page_title = $tr->t('edit_event');
 $is_staff = true;
 $display_name = $_SESSION['display_name'] ?? $_SESSION['username'] ?? '';
 include __DIR__ . '/../templates/header.php';
@@ -129,7 +131,7 @@ include __DIR__ . '/../templates/topbar.php';
 ?>
 <main class="dashboard-main">
     <div class="dashboard-section mb-4">
-        <h2 class="mb-3 section-title">Edit Event</h2>
+        <h2 class="mb-3 section-title"><?= htmlspecialchars($tr->t('edit_event')) ?></h2>
         <p><strong>Upload Path:</strong> <?= htmlspecialchars($event['upload_folder'] ?? '') ?></p>
         <?php if (!empty($eventFiles)): ?>
             <ul class="mb-3">
@@ -142,42 +144,42 @@ include __DIR__ . '/../templates/topbar.php';
             <input type="hidden" name="update_event" value="1">
             <div class="row g-3 align-items-end">
                 <div class="col-md-4">
-                    <label class="form-label">Name</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('name')) ?></label>
                     <input type="text" name="event_name" class="form-control" value="<?= htmlspecialchars($event['event_name']) ?>" required>
                 </div>
                 <div class="col-md-3">
-                    <label class="form-label">Date</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('date')) ?></label>
                     <input type="date" name="event_date" class="form-control" value="<?= htmlspecialchars($event['event_date']) ?>">
                 </div>
                 <div class="col-md-5">
-                    <label class="form-label">Location</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('location')) ?></label>
                     <input type="text" name="event_location" class="form-control" value="<?= htmlspecialchars($event['event_location']) ?>">
                 </div>
                 <div class="col-12 col-md-6">
-                    <label class="form-label">Public URL</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('public_url')) ?></label>
                     <div class="input-group">
                         <input type="text" readonly class="form-control" value="<?= htmlspecialchars((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . '/e/' . $event['public_id']) ?>">
-                        <a href="?event_id=<?= $event_id ?>&regen_public_id=1" class="btn btn-outline-secondary">Regenerate</a>
+                        <a href="?event_id=<?= $event_id ?>&regen_public_id=1&lang=<?= $tr->getLang() ?>" class="btn btn-outline-secondary"><?= htmlspecialchars($tr->t('regenerate')) ?></a>
                     </div>
                     <img src="qr.php?public_id=<?= urlencode($event['public_id']) ?>" alt="QR" width="150" height="150" class="mt-2">
                 </div>
                 <div class="col-12 col-md-5">
-                    <label class="form-label">Header Image</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('header_image')) ?></label>
                     <?php if (!empty($event['header_image'])): ?>
                         <img src="<?= htmlspecialchars($event['header_image']) ?>" class="img-fluid mb-2" alt="header">
                     <?php endif; ?>
                     <input type="file" name="header_image" class="form-control" accept="image/*">
                 </div>
                 <div class="col-12">
-                    <label class="form-label">Description</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('description')) ?></label>
                     <textarea name="description" rows="2" class="form-control"><?= htmlspecialchars($event['description']) ?></textarea>
                 </div>
                 <div class="col-12">
-                    <label class="form-label">Custom CSS</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('custom_css')) ?></label>
                     <textarea name="custom_css" rows="4" class="form-control" placeholder="Optional CSS overrides"><?= htmlspecialchars($event['custom_css'] ?? '') ?></textarea>
                 </div>
                 <div class="col-md-3">
-                    <label class="form-label">Status</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('status')) ?></label>
                     <select name="status" class="form-select">
                         <?php foreach (['Created', 'Started', 'Ended'] as $st): ?>
                             <option value="<?= $st ?>"<?= $event['status'] === $st ? ' selected' : '' ?>><?= $st ?></option>
@@ -185,20 +187,20 @@ include __DIR__ . '/../templates/topbar.php';
                     </select>
                 </div>
                 <div class="col-12">
-                    <button type="submit" class="btn btn-accent mt-2 px-4">Save Changes</button>
+                    <button type="submit" class="btn btn-accent mt-2 px-4"><?= htmlspecialchars($tr->t('save_changes')) ?></button>
                 </div>
             </div>
         </form>
         <hr>
-        <h5 class="mb-2">Guests for This Event</h5>
+        <h5 class="mb-2"><?= htmlspecialchars($tr->t('guests_for_this_event')) ?></h5>
         <div class="table-responsive mb-3">
             <table class="table table-dark table-hover align-middle mb-0" style="background: var(--card-bg);">
                 <thead>
                     <tr>
-                        <th>Name</th>
+                        <th><?= htmlspecialchars($tr->t('name')) ?></th>
                         <th>Email</th>
                         <th>Invite Code</th>
-                        <th style="width:70px;">Action</th>
+                        <th style="width:70px;"><?= htmlspecialchars($tr->t('action')) ?></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -208,7 +210,7 @@ include __DIR__ . '/../templates/topbar.php';
                         <td><?= htmlspecialchars($g['email']) ?></td>
                         <td><?= htmlspecialchars($g['invite_code']) ?></td>
                         <td>
-                            <a href="?event_id=<?= $event_id ?>&remove_guest=<?= $g['guest_id'] ?>" class="btn btn-danger btn-sm" onclick="return confirm('Remove guest?')">
+                            <a href="?event_id=<?= $event_id ?>&remove_guest=<?= $g['guest_id'] ?>&lang=<?= $tr->getLang() ?>" class="btn btn-danger btn-sm" onclick="return confirm('<?= htmlspecialchars($tr->t('remove_guest')) ?>')">
                                 <i class="bi bi-x"></i>
                             </a>
                         </td>
@@ -219,14 +221,14 @@ include __DIR__ . '/../templates/topbar.php';
         </div>
 
 
-        <h5 class="mb-2 mt-4">Add Guests</h5>
+        <h5 class="mb-2 mt-4"><?= htmlspecialchars($tr->t('add_guests')) ?></h5>
         <form method="post" class="mb-0">
             <div class="row g-2">
                 <div class="col-md-8">
                     <?php echo renderGuestSelectInput($all, [], 'add_guest_ids[]'); ?>
                 </div>
                 <div class="col-md-4 align-self-end">
-                    <button class="btn btn-accent px-4" type="submit">Add Selected</button>
+                    <button class="btn btn-accent px-4" type="submit"><?= htmlspecialchars($tr->t('add_selected')) ?></button>
                 </div>
             </div>
             <small class="text-secondary mt-2 d-block">Hold Ctrl/Cmd to select multiple guests.</small>

--- a/public/events.php
+++ b/public/events.php
@@ -9,6 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../src/guests/GuestManager.php';
 require_once __DIR__ . '/../src/guests/guest_helpers.php';
 require_once __DIR__ . '/../src/memories/UploadManager.php';
+require_once __DIR__ . '/../src/Translation.php';
 
 // --- DB Connections ---
 $memDbConf = $config['db_memories'];
@@ -17,6 +18,7 @@ $emDbConf = $config['db_event_manager'];
 $emPdo = new PDO("mysql:host={$emDbConf['host']};dbname={$emDbConf['dbname']};charset={$emDbConf['charset']}", $emDbConf['user'], $emDbConf['pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
 $guestManager = new GuestManager($emPdo, $memPdo);
+$tr = new Translation();
 
 // --- ADD EVENT ---
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['event_name'])) {
@@ -74,7 +76,7 @@ $events = $stmt->fetchAll(PDO::FETCH_ASSOC);
 $all_guests = $guestManager->fetchAllGuests();
 
 // --- Theming Stuff ---
-$page_title = "Events";
+$page_title = $tr->t('events');
 $is_staff = true;
 $display_name = $_SESSION['display_name'] ?? $_SESSION['username'] ?? '';
 include __DIR__ . '/../templates/header.php';
@@ -83,33 +85,33 @@ include __DIR__ . '/../templates/topbar.php';
 ?>
 <main class="dashboard-main">
     <div class="dashboard-section mb-4">
-        <h2 class="mb-3 section-title">Events</h2>
+        <h2 class="mb-3 section-title"><?= htmlspecialchars($tr->t('events')) ?></h2>
         <form method="POST" enctype="multipart/form-data" class="mb-4">
             <div class="row g-3 align-items-end">
                 <div class="col-md-4">
-                    <label class="form-label">Name</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('name')) ?></label>
                     <input type="text" name="event_name" class="form-control" required>
                 </div>
                 <div class="col-md-3">
-                    <label class="form-label">Date</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('date')) ?></label>
                     <input type="date" name="event_date" class="form-control">
                 </div>
                 <div class="col-md-5">
-                    <label class="form-label">Location</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('location')) ?></label>
                     <input type="text" name="event_location" class="form-control">
                 </div>
                 <div class="col-12 col-md-5">
-                    <label class="form-label">Header Image</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('header_image')) ?></label>
                     <input type="file" name="header_image" class="form-control" accept="image/*">
                 </div>
                 <div class="col-12">
-                    <label class="form-label">Description</label>
+                    <label class="form-label"><?= htmlspecialchars($tr->t('description')) ?></label>
                     <textarea name="description" rows="2" class="form-control"></textarea>
                 </div>
                 <?php echo renderGuestSelectInput($all_guests); ?>
 
                 <div class="col-12">
-                    <button type="submit" class="btn btn-accent mt-2 px-4">Add Event</button>
+                    <button type="submit" class="btn btn-accent mt-2 px-4"><?= htmlspecialchars($tr->t('add_event')) ?></button>
                 </div>
             </div>
         </form>
@@ -117,12 +119,12 @@ include __DIR__ . '/../templates/topbar.php';
             <table class="table table-dark table-hover align-middle mb-0" style="background: var(--card-bg); min-width:600px;">
                 <thead style="background: var(--sidebar-bg)">
                     <tr>
-                        <th>Name</th>
-                        <th>Date</th>
-                        <th>Location</th>
-                        <th>Description</th>
-                        <th>Status</th>
-                        <th style="width:120px;">Action</th>
+                        <th><?= htmlspecialchars($tr->t('name')) ?></th>
+                        <th><?= htmlspecialchars($tr->t('date')) ?></th>
+                        <th><?= htmlspecialchars($tr->t('location')) ?></th>
+                        <th><?= htmlspecialchars($tr->t('description')) ?></th>
+                        <th><?= htmlspecialchars($tr->t('status')) ?></th>
+                        <th style="width:120px;"><?= htmlspecialchars($tr->t('action')) ?></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -134,8 +136,8 @@ include __DIR__ . '/../templates/topbar.php';
                         <td><?= htmlspecialchars($event['description']) ?></td>
                         <td><?= htmlspecialchars($event['status'] ?? '') ?></td>
                         <td>
-                            <a href="event.php?event_id=<?= $event['id'] ?>" class="btn btn-accent btn-sm">Edit</a>
-                            <a href="events.php?delete=<?= $event['id'] ?>" class="btn btn-danger btn-sm" onclick="return confirm('Delete this event?')"><i class="bi bi-trash"></i></a>
+                            <a href="event.php?event_id=<?= $event['id'] ?>&lang=<?= $tr->getLang() ?>" class="btn btn-accent btn-sm"><?= htmlspecialchars($tr->t('edit')) ?></a>
+                            <a href="events.php?delete=<?= $event['id'] ?>&lang=<?= $tr->getLang() ?>" class="btn btn-danger btn-sm" onclick="return confirm('<?= htmlspecialchars($tr->t('delete_confirm')) ?>')"><i class="bi bi-trash"></i></a>
                         </td>
                     </tr>
                 <?php endforeach ?>

--- a/public/views/event_public_redesign.php
+++ b/public/views/event_public_redesign.php
@@ -48,6 +48,17 @@
       border-radius: 50px;
       padding: 0.75rem 2rem;
     }
+    .loading-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.8);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-size: 1.5rem;
+      z-index: 200;
+    }
     .memory img, .memory video {
       width: 100%;
       border-radius: 12px;
@@ -76,7 +87,7 @@
     <div class="glass-box">
       <form method="post" enctype="multipart/form-data" id="postForm">
         <input type="hidden" name="new_post" value="1">
-        <input type="file" name="media" id="mediaInput" accept="image/*,video/*" class="d-none" required>
+        <input type="file" name="media" id="mediaInput" accept="image/*,video/*" capture="environment" class="d-none" required>
         <div class="d-flex gap-2 mb-2">
           <button type="button" class="btn btn-secondary flex-fill" id="cameraBtn">Use Camera</button>
           <button type="button" class="btn btn-secondary flex-fill" id="uploadBtn">Choose File</button>
@@ -107,7 +118,9 @@
     </div>
   </div>
 
-  <button class="btn btn-light upload-btn" onclick="document.querySelector('[name=media]').click()">Add Memory</button>
+  <button class="btn btn-light upload-btn" onclick="document.getElementById('cameraBtn').click()">Add Memory</button>
+
+  <div id="loadingOverlay" class="loading-overlay d-none">Loading...</div>
 
   <script>
     const input = document.getElementById('mediaInput');
@@ -131,6 +144,10 @@
             btn.closest('.like-container').querySelector('.like-count').textContent = d.likes;
           });
       });
+    });
+
+    document.getElementById('postForm').addEventListener('submit', () => {
+      document.getElementById('loadingOverlay').classList.remove('d-none');
     });
   </script>
 </body>

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -1,0 +1,75 @@
+<?php
+class Translation
+{
+    private $translations = [
+        'en' => [
+            'events' => 'Events',
+            'add_event' => 'Add Event',
+            'name' => 'Name',
+            'date' => 'Date',
+            'location' => 'Location',
+            'header_image' => 'Header Image',
+            'description' => 'Description',
+            'action' => 'Action',
+            'status' => 'Status',
+            'edit' => 'Edit',
+            'delete_confirm' => 'Delete this event?',
+            'edit_event' => 'Edit Event',
+            'public_url' => 'Public URL',
+            'regenerate' => 'Regenerate',
+            'custom_css' => 'Custom CSS',
+            'save_changes' => 'Save Changes',
+            'guests_for_this_event' => 'Guests for This Event',
+            'add_guests' => 'Add Guests',
+            'add_selected' => 'Add Selected',
+            'remove_guest' => 'Remove guest?',
+        ],
+        'es' => [
+            'events' => 'Eventos',
+            'add_event' => 'Agregar Evento',
+            'name' => 'Nombre',
+            'date' => 'Fecha',
+            'location' => 'Ubicación',
+            'header_image' => 'Imagen de cabecera',
+            'description' => 'Descripción',
+            'action' => 'Acción',
+            'status' => 'Estado',
+            'edit' => 'Editar',
+            'delete_confirm' => '¿Eliminar este evento?',
+            'edit_event' => 'Editar Evento',
+            'public_url' => 'URL Pública',
+            'regenerate' => 'Regenerar',
+            'custom_css' => 'CSS Personalizado',
+            'save_changes' => 'Guardar Cambios',
+            'guests_for_this_event' => 'Invitados a este Evento',
+            'add_guests' => 'Agregar Invitados',
+            'add_selected' => 'Agregar Seleccionados',
+            'remove_guest' => '¿Eliminar invitado?',
+        ],
+    ];
+
+    private $lang = 'en';
+
+    public function __construct()
+    {
+        if (isset($_GET['lang']) && isset($this->translations[$_GET['lang']])) {
+            $this->lang = $_GET['lang'];
+            $_SESSION['lang'] = $this->lang;
+        } elseif (isset($_SESSION['lang']) && isset($this->translations[$_SESSION['lang']])) {
+            $this->lang = $_SESSION['lang'];
+        }
+    }
+
+    public function t(string $key): string
+    {
+        if (isset($this->translations[$this->lang][$key])) {
+            return $this->translations[$this->lang][$key];
+        }
+        return $this->translations['en'][$key] ?? $key;
+    }
+
+    public function getLang(): string
+    {
+        return $this->lang;
+    }
+}


### PR DESCRIPTION
## Summary
- enable translations on events management pages with new `Translation` class
- show Android camera option by default and add loading overlay
- document language option in README

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_68823d9715b0832eb66934a711e5600c