### PR TITLE
Add device info tracking to news reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A simple PHP application for managing events and guests. This project is a small
 12. Ensure the PHP EXIF extension is enabled so photos taken on phones keep their correct orientation.
 13. Run the SQL in `sql/alter_add_news_images.sql` to add support for multiple images in news posts.
 14. You can now edit or delete news posts from the **News** page. Click *Edit* next to a post to modify or remove it. The edit screen also lets you reorder existing images using the arrow buttons. No additional setup is required.
+15. Run the SQL in `sql/alter_add_news_device.sql` to start logging which devices open news posts.
 
 ## Running
 Use PHP's built-in server from the project root:

--- a/public/news_view.php
+++ b/public/news_view.php
@@ -55,8 +55,9 @@ if (!$guestId) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['mode'] ?? '') === 'newsopened') {
-    $stmt = $memPdo->prepare('INSERT INTO news_reads (news_id, guest_id) VALUES (?, ?)');
-    $stmt->execute([$news['id'], $guestId]);
+    $device = $_SERVER['HTTP_USER_AGENT'] ?? '';
+    $stmt = $memPdo->prepare('INSERT INTO news_reads (news_id, guest_id, device_info) VALUES (?, ?, ?)');
+    $stmt->execute([$news['id'], $guestId, $device]);
     header('Content-Type: application/json');
     echo json_encode(['success' => true]);
     exit;

--- a/sql/alter_add_news_device.sql
+++ b/sql/alter_add_news_device.sql
@@ -1,0 +1,1 @@
+ALTER TABLE news_reads ADD COLUMN device_info VARCHAR(255) DEFAULT NULL;

--- a/sql/create_news_tables.sql
+++ b/sql/create_news_tables.sql
@@ -11,5 +11,6 @@ CREATE TABLE news_reads (
     id INT AUTO_INCREMENT PRIMARY KEY,
     news_id INT NOT NULL,
     guest_id INT NOT NULL,
+    device_info VARCHAR(255) DEFAULT NULL,
     opened_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- capture user agent in `news_view.php`
- add `device_info` column in `create_news_tables.sql`
- provide `alter_add_news_device.sql` migration
- document new SQL step in README

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_6882ad7f3294832e8ecefc7a548d53a1