### PR TITLE
Add form editing and deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A simple PHP application for managing events and guests. This project is a small
 15. Run the SQL in `sql/alter_add_news_device.sql` to start logging which devices open news posts.
 16. Run the SQL in `sql/create_forms_tables.sql` to enable the Forms builder feature.
 17. The Forms builder now supports `textarea`, `select` and `radio` fields. Forms using radio buttons auto-submit as soon as a choice is made.
+18. You can now edit or delete forms from the **Forms** page. Click *Edit* next to a form to modify its fields or remove it entirely.
 
 
 ## Running

--- a/public/forms_admin.php
+++ b/public/forms_admin.php
@@ -22,6 +22,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['name'])) {
     exit;
 }
 
+if (isset($_GET['delete'])) {
+    $id = intval($_GET['delete']);
+    $pdo->prepare('DELETE FROM form_submissions WHERE form_id=?')->execute([$id]);
+    $pdo->prepare('DELETE FROM forms WHERE id=?')->execute([$id]);
+    header('Location: forms_admin.php');
+    exit;
+}
+
 $forms = $pdo->query('SELECT * FROM forms ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
 
 $page_title = 'Forms';
@@ -50,6 +58,7 @@ include __DIR__ . '/../templates/topbar.php';
                     <tr>
                         <th>Name</th>
                         <th>Embed</th>
+                        <th style="width:120px;">Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -57,6 +66,10 @@ include __DIR__ . '/../templates/topbar.php';
                     <tr>
                         <td><?= htmlspecialchars($f['name']) ?></td>
                         <td><code>&lt;iframe src="/form_embed.php?slug=<?= htmlspecialchars($f['slug']) ?>" style="border:0;width:100%;"&gt;&lt;/iframe&gt;</code></td>
+                        <td>
+                            <a href="forms_edit.php?id=<?= $f['id'] ?>" class="btn btn-secondary btn-sm">Edit</a>
+                            <a href="forms_admin.php?delete=<?= $f['id'] ?>" class="btn btn-danger btn-sm" onclick="return confirm('Delete this form?')"><i class="bi bi-trash"></i></a>
+                        </td>
                     </tr>
                 <?php endforeach ?>
                 </tbody>

--- a/public/forms_edit.php
+++ b/public/forms_edit.php
@@ -1,0 +1,137 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login');
+    exit;
+}
+
+$config = require __DIR__ . '/../config/config.php';
+$memDbConf = $config['db_memories'];
+$pdo = new PDO(
+    "mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}",
+    $memDbConf['user'],
+    $memDbConf['pass'],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+
+$formId = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if (!$formId) {
+    die('Form ID missing');
+}
+
+// Fetch form
+$stmt = $pdo->prepare('SELECT * FROM forms WHERE id=?');
+$stmt->execute([$formId]);
+$form = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$form) {
+    die('Form not found');
+}
+
+if (isset($_GET['delete'])) {
+    $pdo->prepare('DELETE FROM form_submissions WHERE form_id=?')->execute([$formId]);
+    $pdo->prepare('DELETE FROM forms WHERE id=?')->execute([$formId]);
+    header('Location: forms_admin.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['name'])) {
+    $fields = $_POST['fields'] ?? '[]';
+    $stmt = $pdo->prepare('UPDATE forms SET name=?, fields=? WHERE id=?');
+    $stmt->execute([$_POST['name'], $fields, $formId]);
+    header('Location: forms_admin.php');
+    exit;
+}
+
+$fields = json_decode($form['fields'], true) ?: [];
+
+$page_title = 'Edit Form';
+$is_staff = true;
+$display_name = $_SESSION['display_name'] ?? $_SESSION['username'] ?? '';
+include __DIR__ . '/../templates/header.php';
+include __DIR__ . '/../templates/sidebar.php';
+include __DIR__ . '/../templates/topbar.php';
+?>
+<main class="dashboard-main">
+    <div class="dashboard-section mb-4">
+        <h2 class="mb-3 section-title">Edit Form</h2>
+        <form method="post" id="form-builder" class="mb-4">
+            <div class="mb-3">
+                <label class="form-label">Name</label>
+                <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($form['name']) ?>" required>
+            </div>
+            <div id="fields"></div>
+            <button type="button" id="add-field" class="btn btn-secondary btn-sm mb-3">Add Field</button>
+            <input type="hidden" name="fields" id="fields-input">
+            <button type="submit" class="btn btn-accent">Save</button>
+            <a href="forms_edit.php?id=<?= $formId ?>&delete=1" class="btn btn-danger ms-2" onclick="return confirm('Delete this form?')"><i class="bi bi-trash"></i></a>
+        </form>
+    </div>
+</main>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var fieldsDiv = document.getElementById('fields');
+        var fieldsInput = document.getElementById('fields-input');
+        var existing = <?php echo json_encode($fields); ?>;
+        existing.forEach(function (f) {
+            addRow(f);
+        });
+        document.getElementById('add-field').addEventListener('click', function () {
+            addRow();
+        });
+        fieldsDiv.addEventListener('click', function (e) {
+            if (e.target.classList.contains('remove-field')) {
+                e.target.closest('.row').remove();
+            }
+        });
+        fieldsDiv.addEventListener('change', function (e) {
+            if (e.target.getAttribute('data-role') === 'type') {
+                var optionsCol = e.target.closest('.row').querySelector('.options-col');
+                if (e.target.value === 'select' || e.target.value === 'radio') {
+                    optionsCol.classList.remove('d-none');
+                } else {
+                    optionsCol.classList.add('d-none');
+                }
+            }
+        });
+        document.getElementById('form-builder').addEventListener('submit', function () {
+            var arr = [];
+            fieldsDiv.querySelectorAll('.row').forEach(function (row) {
+                arr.push({
+                    label: row.querySelector('[data-role="label"]').value,
+                    name: row.querySelector('[data-role="name"]').value,
+                    type: row.querySelector('[data-role="type"]').value,
+                    options: row.querySelector('[data-role="options"]').value
+                });
+            });
+            fieldsInput.value = JSON.stringify(arr);
+        });
+
+        function addRow(field) {
+            var row = document.createElement('div');
+            row.className = 'row g-2 mb-2 align-items-end';
+            row.innerHTML = '<div class="col"><input type="text" class="form-control" placeholder="Label" data-role="label"></div>' +
+                '<div class="col"><input type="text" class="form-control" placeholder="Name" data-role="name"></div>' +
+                '<div class="col"><select class="form-select" data-role="type">' +
+                '<option value="text">Text</option>' +
+                '<option value="email">Email</option>' +
+                '<option value="number">Number</option>' +
+                '<option value="textarea">Textarea</option>' +
+                '<option value="select">Select</option>' +
+                '<option value="radio">Radio</option>' +
+                '</select></div>' +
+                '<div class="col options-col d-none"><input type="text" class="form-control" placeholder="Options (comma separated)" data-role="options"></div>' +
+                '<div class="col-auto"><button type="button" class="btn btn-danger btn-sm remove-field">Remove</button></div>';
+            fieldsDiv.appendChild(row);
+            if (field) {
+                row.querySelector('[data-role="label"]').value = field.label || '';
+                row.querySelector('[data-role="name"]').value = field.name || '';
+                row.querySelector('[data-role="type"]').value = field.type || 'text';
+                row.querySelector('[data-role="options"]').value = field.options || '';
+                if (field.type === 'select' || field.type === 'radio') {
+                    row.querySelector('.options-col').classList.remove('d-none');
+                }
+            }
+        }
+    });
+</script>
+<?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -23,6 +23,8 @@ switch ($path) {
         require 'news_edit.php'; break;
     case 'forms_admin':
         require 'forms_admin.php'; break;
+    case 'forms_edit':
+        require 'forms_edit.php'; break;
     case 'form_submit.php':
         require 'form_submit.php'; break;
     case 'find_event':
@@ -44,7 +46,7 @@ if (preg_match('#^news/([A-Za-z0-9]+)$#', $path, $m)) {
     return;
 }
 
-if ($path !== '' && !in_array($path, ['dashboard','events','login','logout','guest_portal','guests','find_event','news_admin','news_edit','forms_admin','form_submit.php'])) {
+if ($path !== '' && !in_array($path, ['dashboard','events','login','logout','guest_portal','guests','find_event','news_admin','news_edit','forms_admin','forms_edit','form_submit.php'])) {
     http_response_code(404);
     echo "404 Not Found";
 }


### PR DESCRIPTION
## Summary
- enable editing and deleting of forms
- add new `forms_edit.php` page
- link edit page from router and forms list
- document new capabilities in README

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_6882b1db8a10832eb0073f2b9c924930