### PR TITLE
Fix background image quoting in form embed

### DIFF
--- a/public/form_embed.php
+++ b/public/form_embed.php
@@ -58,7 +58,7 @@ if ($guestId) {
 }
 $fields = json_decode($form['fields'], true) ?: [];
 ?>
-<div class="container-fluid py-4" style="background-image: url("https://kaljusaar.ams3.cdn.digitaloceanspaces.com/uploads/taust.jpg"; background-color: #f5f3ee;">
+<div class="container-fluid py-4" style="background-image: url('https://kaljusaar.ams3.cdn.digitaloceanspaces.com/uploads/taust.jpg'); background-color: #f5f3ee;">
   <div class="d-flex justify-content-center">
 <?php if ($already): ?>
     <div class="alert alert-success">Aitäh vastuse eest!</div>


### PR DESCRIPTION
## Summary
- fix HTML style attribute quoting so the embedded form parses correctly

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_6882be83b634832e8f5914b25ff1830e