### PR TITLE
Persist invite code

### DIFF
--- a/public/form_embed.php
+++ b/public/form_embed.php
@@ -1,25 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Form Example</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        body {
-            background-image: url("https://kaljusaar.ams3.cdn.digitaloceanspaces.com/uploads/taust.jpg");
-            background-color: #E9E3DF;
-        }
-        /* Optional: Form shadow and max width for aesthetics */
-        .center-form {
-            min-width: 320px;
-            max-width: 600px;
-            width: 100%;
-        }
-    </style>
-</head>
-<body>
 <?php
+session_start();
 $config = require __DIR__ . '/../config/config.php';
+
 $memDbConf = $config['db_memories'];
 $pdo = new PDO(
     "mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}",
@@ -34,8 +16,15 @@ $emPdo = new PDO(
     $emDbConf['pass'],
     [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
 );
+
 $slug = $_GET['slug'] ?? '';
 $code = $_GET['code'] ?? ($_GET['invite'] ?? '');
+if ($code === '' && !empty($_SESSION['invite_code'])) {
+    $code = $_SESSION['invite_code'];
+} elseif ($code !== '') {
+    $_SESSION['invite_code'] = $code;
+}
+
 $stmt = $pdo->prepare('SELECT * FROM forms WHERE slug=?');
 $stmt->execute([$slug]);
 $form = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -44,6 +33,7 @@ if (!$form) {
     echo 'Form not found';
     exit;
 }
+
 $guestId = null;
 if ($code !== '') {
     $gStmt = $emPdo->prepare('SELECT id FROM guests WHERE invite_code=? AND rsvp_status="Accepted"');
@@ -58,6 +48,25 @@ if ($guestId) {
 }
 $fields = json_decode($form['fields'], true) ?: [];
 ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Form Example</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            background-image: url("https://kaljusaar.ams3.cdn.digitaloceanspaces.com/uploads/taust.jpg");
+            background-color: #E9E3DF;
+        }
+        .center-form {
+            min-width: 320px;
+            max-width: 600px;
+            width: 100%;
+        }
+    </style>
+</head>
+<body>
 <div class="container-fluid py-4" style="background-image: url('https://kaljusaar.ams3.cdn.digitaloceanspaces.com/uploads/taust.jpg'); background-color: #f5f3ee;">
   <div class="d-flex justify-content-center">
 <?php if ($already): ?>
@@ -93,9 +102,6 @@ $fields = json_decode($form['fields'], true) ?: [];
                 <?php endif ?>
             </div>
         <?php endforeach ?>
-        <!-- No need for a submit button if auto-submit, but uncomment if needed:
-        <button type="submit" class="btn btn-primary">Submit</button>
-        -->
     </form>
 <?php endif ?>
   </div>

--- a/public/form_submit.php
+++ b/public/form_submit.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 $config = require __DIR__ . '/../config/config.php';
 $memDbConf = $config['db_memories'];
 $pdo = new PDO(
@@ -16,6 +17,11 @@ if (!$form) {
     exit('Not found');
 }
 $code = $_GET['code'] ?? ($_GET['invite'] ?? '');
+if ($code === '' && !empty($_SESSION['invite_code'])) {
+    $code = $_SESSION['invite_code'];
+} elseif ($code !== '') {
+    $_SESSION['invite_code'] = $code;
+}
 $guestId = null;
 if ($code !== '') {
     $emDbConf = $config['db_event_manager'];

--- a/public/news_view.php
+++ b/public/news_view.php
@@ -15,6 +15,11 @@ if (isset($_SERVER['PATH_INFO'])) {
 } elseif (isset($_GET['invite'])) {
     $code = $_GET['invite'];
 }
+if ($code === '' && !empty($_SESSION['invite_code'])) {
+    $code = $_SESSION['invite_code'];
+} elseif ($code !== '') {
+    $_SESSION['invite_code'] = $code;
+}
 
 function show_error(string $msg): void {
     echo '<div style="color:#c00;font-size:1.3em;text-align:center;margin-top:100px;">'.htmlspecialchars($msg).'</div>';


### PR DESCRIPTION
## Summary
- persist invite code into the session when present
- fall back to session invite code in embeds and submissions

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_6882bfc5df3c832eb7ee1e58d12eabcf