### PR TITLE
Add stats views

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A simple PHP application for managing events and guests. This project is a small
 18. You can now edit or delete forms from the **Forms** page. Click *Edit* next to a form to modify its fields or remove it entirely.
 19. Run the SQL in `sql/alter_add_news_content_position.sql` to allow placing the news content between uploaded images.
 20. Run the SQL in `sql/alter_add_form_guest.sql` to associate form submissions with guests.
+21. View form submissions under **Form Results** and news device statistics on the **News Stats** page. No additional setup is required.
 
 
 ## Running

--- a/public/forms_results.php
+++ b/public/forms_results.php
@@ -1,0 +1,114 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login');
+    exit;
+}
+$config = require __DIR__ . '/../config/config.php';
+$memDbConf = $config['db_memories'];
+$pdo = new PDO(
+    "mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}",
+    $memDbConf['user'],
+    $memDbConf['pass'],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+
+$formId = isset($_GET['id']) ? intval($_GET['id']) : 0;
+
+if (!$formId) {
+    $forms = $pdo->query('SELECT id, name FROM forms ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+    $page_title = 'Form Results';
+    $is_staff = true;
+    $display_name = $_SESSION['display_name'] ?? $_SESSION['username'] ?? '';
+    include __DIR__ . '/../templates/header.php';
+    include __DIR__ . '/../templates/sidebar.php';
+    include __DIR__ . '/../templates/topbar.php';
+    echo "<main class=\"dashboard-main\"><div class=\"dashboard-section mb-4\">";
+    echo "<h2 class=\"mb-3 section-title\">Form Results</h2>";
+    echo '<ul class="list-unstyled">';
+    foreach ($forms as $f) {
+        echo '<li><a href="forms_results.php?id=' . $f['id'] . '">' . htmlspecialchars($f['name']) . '</a></li>';
+    }
+    echo '</ul></div></main>';
+    include __DIR__ . '/../templates/footer.php';
+    return;
+}
+
+$stmt = $pdo->prepare('SELECT * FROM forms WHERE id=?');
+$stmt->execute([$formId]);
+$form = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$form) {
+    die('Form not found');
+}
+
+$fields = json_decode($form['fields'], true) ?: [];
+$fieldLabels = [];
+$stats = [];
+foreach ($fields as $f) {
+    $fieldLabels[$f['name']] = $f['label'];
+    if (in_array($f['type'], ['select','radio'])) {
+        $opts = array_map('trim', explode(',', $f['options']));
+        foreach ($opts as $o) {
+            $stats[$f['name']][$o] = 0;
+        }
+    }
+}
+
+$subsStmt = $pdo->prepare('SELECT * FROM form_submissions WHERE form_id=? ORDER BY submitted_at DESC');
+$subsStmt->execute([$formId]);
+$submissions = $subsStmt->fetchAll(PDO::FETCH_ASSOC);
+foreach ($submissions as $s) {
+    $data = json_decode($s['data'], true) ?: [];
+    foreach ($stats as $fname => $opts) {
+        if (isset($data[$fname]) && isset($opts[$data[$fname]])) {
+            $stats[$fname][$data[$fname]]++;
+        }
+    }
+}
+
+$page_title = 'Form Results';
+$is_staff = true;
+$display_name = $_SESSION['display_name'] ?? $_SESSION['username'] ?? '';
+include __DIR__ . '/../templates/header.php';
+include __DIR__ . '/../templates/sidebar.php';
+include __DIR__ . '/../templates/topbar.php';
+?>
+<main class="dashboard-main">
+    <div class="dashboard-section mb-4">
+        <h2 class="mb-3 section-title"><?= htmlspecialchars($form['name']) ?> Submissions</h2>
+        <div class="table-responsive mb-4">
+            <table class="table table-dark table-hover align-middle mb-0" style="background: var(--card-bg);">
+                <thead>
+                    <tr>
+                        <th>Submitted</th>
+<?php foreach ($fields as $f): ?>
+                        <th><?= htmlspecialchars($f['label']) ?></th>
+<?php endforeach ?>
+                    </tr>
+                </thead>
+                <tbody>
+<?php foreach ($submissions as $sub): $data = json_decode($sub['data'], true) ?: []; ?>
+                    <tr>
+                        <td><?= htmlspecialchars($sub['submitted_at']) ?></td>
+<?php foreach ($fields as $f): ?>
+                        <td><?= htmlspecialchars($data[$f['name']] ?? '') ?></td>
+<?php endforeach ?>
+                    </tr>
+<?php endforeach ?>
+                </tbody>
+            </table>
+        </div>
+<?php if ($stats): ?>
+        <h3 class="mb-3">Statistics</h3>
+<?php foreach ($stats as $fname => $opts): ?>
+        <h5><?= htmlspecialchars($fieldLabels[$fname]) ?></h5>
+        <ul>
+<?php foreach ($opts as $opt => $cnt): ?>
+            <li><?= htmlspecialchars($opt) ?>: <?= $cnt ?></li>
+<?php endforeach ?>
+        </ul>
+<?php endforeach ?>
+<?php endif ?>
+    </div>
+</main>
+<?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -25,10 +25,14 @@ switch ($path) {
         require 'forms_admin.php'; break;
     case 'forms_edit':
         require 'forms_edit.php'; break;
+    case 'forms_results':
+        require 'forms_results.php'; break;
     case 'form_submit.php':
         require 'form_submit.php'; break;
     case 'find_event':
         require 'find_event.php'; break;
+    case 'news_stats':
+        require 'news_stats.php'; break;
     default:
         // handled below
         break;
@@ -46,7 +50,7 @@ if (preg_match('#^news/([A-Za-z0-9]+)$#', $path, $m)) {
     return;
 }
 
-if ($path !== '' && !in_array($path, ['dashboard','events','login','logout','guest_portal','guests','find_event','news_admin','news_edit','forms_admin','forms_edit','form_submit.php'])) {
+if ($path !== '' && !in_array($path, ['dashboard','events','login','logout','guest_portal','guests','find_event','news_admin','news_edit','forms_admin','forms_edit','forms_results','form_submit.php','news_stats'])) {
     http_response_code(404);
     echo "404 Not Found";
 }

--- a/public/news_stats.php
+++ b/public/news_stats.php
@@ -1,0 +1,80 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login');
+    exit;
+}
+$config = require __DIR__ . '/../config/config.php';
+$memDbConf = $config['db_memories'];
+$pdo = new PDO(
+    "mysql:host={$memDbConf['host']};dbname={$memDbConf['dbname']};charset={$memDbConf['charset']}",
+    $memDbConf['user'],
+    $memDbConf['pass'],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+
+function classify_device(string $ua): string {
+    $ua = strtolower($ua);
+    if (strpos($ua, 'iphone') !== false) return 'iPhone';
+    if (strpos($ua, 'ipad') !== false) return 'iPad';
+    if (strpos($ua, 'android') !== false) return 'Android';
+    if (strpos($ua, 'windows') !== false) return 'Windows';
+    if (strpos($ua, 'macintosh') !== false || strpos($ua, 'mac os') !== false) return 'Mac';
+    return 'Other';
+}
+
+$newsId = isset($_GET['id']) ? intval($_GET['id']) : 0;
+
+if (!$newsId) {
+    $news = $pdo->query('SELECT id,title FROM news ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+    $page_title = 'News Stats';
+    $is_staff = true;
+    $display_name = $_SESSION['display_name'] ?? $_SESSION['username'] ?? '';
+    include __DIR__ . '/../templates/header.php';
+    include __DIR__ . '/../templates/sidebar.php';
+    include __DIR__ . '/../templates/topbar.php';
+    echo "<main class=\"dashboard-main\"><div class=\"dashboard-section mb-4\">";
+    echo "<h2 class=\"mb-3 section-title\">News Stats</h2>";
+    echo '<ul class="list-unstyled">';
+    foreach ($news as $n) {
+        echo '<li><a href="news_stats.php?id=' . $n['id'] . '">' . htmlspecialchars($n['title']) . '</a></li>';
+    }
+    echo '</ul></div></main>';
+    include __DIR__ . '/../templates/footer.php';
+    return;
+}
+
+$stmt = $pdo->prepare('SELECT title FROM news WHERE id=?');
+$stmt->execute([$newsId]);
+$title = $stmt->fetchColumn();
+if (!$title) {
+    die('News not found');
+}
+$readsStmt = $pdo->prepare('SELECT device_info FROM news_reads WHERE news_id=?');
+$readsStmt->execute([$newsId]);
+$reads = $readsStmt->fetchAll(PDO::FETCH_COLUMN);
+$devices = [];
+foreach ($reads as $ua) {
+    $dev = classify_device($ua ?: '');
+    $devices[$dev] = ($devices[$dev] ?? 0) + 1;
+}
+$page_title = 'News Stats';
+$is_staff = true;
+$display_name = $_SESSION['display_name'] ?? $_SESSION['username'] ?? '';
+include __DIR__ . '/../templates/header.php';
+include __DIR__ . '/../templates/sidebar.php';
+include __DIR__ . '/../templates/topbar.php';
+?>
+<main class="dashboard-main">
+    <div class="dashboard-section mb-4">
+        <h2 class="mb-3 section-title">Stats for <?= htmlspecialchars($title) ?></h2>
+        <p>Total reads: <?= count($reads) ?></p>
+        <h5>Devices</h5>
+        <ul>
+<?php foreach ($devices as $d => $c): ?>
+            <li><?= htmlspecialchars($d) ?>: <?= $c ?></li>
+<?php endforeach ?>
+        </ul>
+    </div>
+</main>
+<?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/templates/sidebar.php
+++ b/templates/sidebar.php
@@ -11,7 +11,9 @@ if (!isset($display_name)) $display_name = '';
         
         <a href="/up" class="nav-link<?= strpos($_SERVER['REQUEST_URI'],'/up')===0?' active':'' ?>"><i class="bi bi-cloud-arrow-up"></i> <span class="ms-2">Uploads</span></a>
         <a href="/news_admin" class="nav-link<?= strpos($_SERVER['REQUEST_URI'],'/news_admin')===0?' active':'' ?>"><i class="bi bi-newspaper"></i> <span class="ms-2">News</span></a>
+        <a href="/news_stats" class="nav-link<?= strpos($_SERVER['REQUEST_URI'],'/news_stats')===0?' active':'' ?>"><i class="bi bi-bar-chart"></i> <span class="ms-2">News Stats</span></a>
         <a href="/forms_admin" class="nav-link<?= strpos($_SERVER['REQUEST_URI'],'/forms_admin')===0?' active':'' ?>"><i class="bi bi-ui-checks"></i> <span class="ms-2">Forms</span></a>
+        <a href="/forms_results" class="nav-link<?= strpos($_SERVER['REQUEST_URI'],'/forms_results')===0?' active':'' ?>"><i class="bi bi-clipboard-data"></i> <span class="ms-2">Form Results</span></a>
         <a href="/tasks" class="nav-link<?= strpos($_SERVER['REQUEST_URI'],'/tasks')===0?' active':'' ?>"><i class="bi bi-list-task"></i> <span class="ms-2">Tasks</span></a>
     </div>
     <div class="sidebar-bottom">


### PR DESCRIPTION
## Summary
- implement `forms_results.php` to show submissions and option counts
- implement `news_stats.php` for device statistics on news reads
- route new pages in `index.php`
- link to stats pages from sidebar
- document feature in README

All lint checks (`php -l public/*.php`) pass.


------
https://chatgpt.com/codex/tasks/task_e_68834be4e8e8832ebb6668aa43d526ac