### PR TITLE
Enable event-specific guest selection for email

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Staff users can browse all uploaded memories on the **Uploads** page in the dash
 Click **View Guests** next to an event on the **Events** page to see everyone assigned to that event. The guest list screen now includes an **Email Guests** button that links directly to the email form.
 
 ## Emailing Guests
-Use the **Email Guests** page in the sidebar to send messages to one or more guests. You can also open this page from the **Email Guests** button on an event's guest list. Select the recipients, enter a subject and message then click **Send**. SMTP credentials must be configured as described in the setup section.
+Use the **Email Guests** page in the sidebar to send messages to one or more guests. You can also open this page from the **Email Guests** button on an event's guest list. When opened this way the form automatically selects everyone assigned to that event. Select the recipients, enter a subject and message then click **Send**. SMTP credentials must be configured as described in the setup section.
 
 ## Development Notes
 Run `php -l public/*.php` before committing to ensure there are no syntax errors.

--- a/public/send_email.php
+++ b/public/send_email.php
@@ -29,6 +29,14 @@ $tr = new Translation();
 $guestManager = new GuestManager($emPdo, $memPdo);
 $all_guests = $guestManager->fetchAllGuests();
 
+$event_id = isset($_GET['event_id']) ? intval($_GET['event_id']) : 0;
+$selected_guests = [];
+if ($event_id) {
+    $idsStmt = $memPdo->prepare('SELECT guest_id FROM event_guests WHERE event_id=?');
+    $idsStmt->execute([$event_id]);
+    $selected_guests = $idsStmt->fetchAll(PDO::FETCH_COLUMN);
+}
+
 $sent = false;
 $error = '';
 
@@ -86,7 +94,7 @@ include __DIR__ . '/../templates/topbar.php';
         <form method="post">
             <div class="mb-3">
                 <label class="form-label">Recipients</label>
-                <?php echo renderGuestSelectInput($all_guests); ?>
+                <?php echo renderGuestSelectInput($all_guests, $selected_guests); ?>
             </div>
             <div class="mb-3">
                 <label class="form-label">Subject</label>

--- a/public/view_guests.php
+++ b/public/view_guests.php
@@ -71,7 +71,7 @@ include __DIR__ . '/../templates/topbar.php';
             <?= htmlspecialchars($tr->t('guests_for_this_event')) ?>: 
             <span class="text-accent"><?= htmlspecialchars($event['event_name']) ?></span>
         </h2>
-        <a href="send_email.php" class="btn btn-accent btn-sm mb-3">Email Guests</a>
+        <a href="send_email.php?event_id=<?= $event_id ?>" class="btn btn-accent btn-sm mb-3">Email Guests</a>
         <div class="table-responsive mb-3">
             <table class="table table-dark table-hover align-middle mb-0" style="background: var(--card-bg);">
                 <thead>


### PR DESCRIPTION
## Summary
- preselect event guests on the email form when opened from guest list
- link to `send_email.php` now passes the event ID
- document automatic recipient selection in README

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_688374ad3f34832eb956159f09d6e605