### PR TITLE
Switch to MailerSend API for emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A simple PHP application for managing events and guests. This project is a small
 19. Run the SQL in `sql/alter_add_news_content_position.sql` to allow placing the news content between uploaded images.
 20. Run the SQL in `sql/alter_add_form_guest.sql` to associate form submissions with guests.
 21. View form submissions under **Form Results** and see which guests read each news post on the **News Stats** page. No additional setup is required.
-22. Configure the new `smtp` settings in `config/config.php` if you want to email guests. When using a Microsoft 365 shared mailbox set `host` to `smtp.office365.com`, `port` to `587` and `encryption` to `tls`. Use the credentials of a user with **Send As** rights and set `from_email` to the shared mailbox address.
+22. Configure the new `mailersend` settings in `config/config.php` to enable sending emails via MailerSend. Provide your API key and set `from_email` and `from_name` to the desired sender details.
 
 
 ## Running
@@ -61,7 +61,7 @@ Staff users can browse all uploaded memories on the **Uploads** page in the dash
 Click **View Guests** next to an event on the **Events** page to see everyone assigned to that event. The guest list screen now includes an **Email Guests** button that links directly to the email form.
 
 ## Emailing Guests
-Use the **Email Guests** page in the sidebar to send messages to one or more guests. You can also open this page from the **Email Guests** button on an event's guest list. When opened this way the form automatically selects everyone assigned to that event. Select the recipients, enter a subject and message then click **Send**. SMTP credentials must be configured as described in the setup section.
+Use the **Email Guests** page in the sidebar to send messages to one or more guests. You can also open this page from the **Email Guests** button on an event's guest list. When opened this way the form automatically selects everyone assigned to that event. Select the recipients, enter a subject and message then click **Send**. MailerSend credentials must be configured as described in the setup section.
 
 ## Development Notes
 Run `php -l public/*.php` before committing to ensure there are no syntax errors.

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "require": {
         "aws/aws-sdk-php": "^3.351",
         "endroid/qr-code": "~5.0",
-        "phpmailer/phpmailer": "^6.10"
+        "phpmailer/phpmailer": "^6.10",
+        "mailersend/mailersend": "^0.34.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/config/config-example.php
+++ b/config/config-example.php
@@ -40,6 +40,13 @@ return [
         'from_name'  => 'Memories Team',
     ],
 
+    // --- MailerSend Settings ---
+    'mailersend' => [
+        'api_key'    => 'HIDDEN',
+        'from_email' => 'noreply@example.com',
+        'from_name'  => 'Memories Team',
+    ],
+
     // --- App Config (optional) ---
     'app' => [
         'env'       => 'development',


### PR DESCRIPTION
## Summary
- add mailersend/mailersend dependency
- configure new `mailersend` settings in config example
- update README to mention MailerSend configuration
- send emails via MailerSend API instead of SMTP

All `php -l public/*.php` checks pass.


------
https://chatgpt.com/codex/tasks/task_e_688376b28f28832e84019039ee3e3396