### PR TITLE
Improve MailerSend error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ nbproject/
 .cache/
 uploads/
 public/uploads/
+logs/
 *.bak
 
 # Ignore environment & secret config

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A simple PHP application for managing events and guests. This project is a small
 20. Run the SQL in `sql/alter_add_form_guest.sql` to associate form submissions with guests.
 21. View form submissions under **Form Results** and see which guests read each news post on the **News Stats** page. No additional setup is required.
 22. Configure the new `mailersend` settings in `config/config.php` to enable sending emails via MailerSend. Provide your API key and set `from_email` and `from_name` to the desired sender details.
+23. Errors returned by MailerSend are logged to `logs/mailersend.log`. Ensure the `logs` directory is writable.
 
 
 ## Running


### PR DESCRIPTION
## Summary
- log MailerSend errors to `logs/mailersend.log`
- capture API error responses when sending email
- ignore the new `logs/` folder
- document the log location in the setup instructions

All `php -l public/*.php` checks pass.


------
https://chatgpt.com/codex/tasks/task_e_68837fa1b718832ead91d950e4848f60