### PR TITLE
Add MailerSend test utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A simple PHP application for managing events and guests. This project is a small
 21. View form submissions under **Form Results** and see which guests read each news post on the **News Stats** page. No additional setup is required.
 22. Configure the new `mailersend` settings in `config/config.php` to enable sending emails via MailerSend. Provide your API key and set `from_email` and `from_name` to the desired sender details.
 23. Errors returned by MailerSend are logged to `logs/mailersend.log`. Ensure the `logs` directory is writable.
+24. Run `php public/test_mailersend.php you@example.com` to send a test message and verify your MailerSend API connection.
 
 
 ## Running

--- a/public/test_mailersend.php
+++ b/public/test_mailersend.php
@@ -1,0 +1,37 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+$config = require __DIR__ . '/../config/config.php';
+
+use MailerSend\MailerSend;
+use MailerSend\Helpers\Builder\EmailParams;
+use MailerSend\Helpers\Builder\Recipient;
+use MailerSend\Exceptions\MailerSendHttpException;
+
+$to = $argv[1] ?? null;
+if (!$to) {
+    echo "Usage: php test_mailersend.php recipient@example.com\n";
+    exit(1);
+}
+
+$msConf = $config['mailersend'];
+
+try {
+    $mailersend = new MailerSend(['api_key' => $msConf['api_key']]);
+
+    $emailParams = (new EmailParams())
+        ->setFrom($msConf['from_email'])
+        ->setFromName($msConf['from_name'])
+        ->setRecipients([new Recipient($to, 'Test User')])
+        ->setSubject('MailerSend API Test')
+        ->setText('This is a test email from test_mailersend.php')
+        ->setHtml('<p>This is a test email from test_mailersend.php</p>');
+
+    $mailersend->email->send($emailParams);
+    echo "Message sent successfully!\n";
+} catch (MailerSendHttpException $e) {
+    echo "MailerSend error: " . $e->getMessage() . "\n";
+    exit(1);
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add `public/test_mailersend.php` to verify MailerSend API connectivity
- document how to run the test script in the setup section of the README

## Testing
- `php -l public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_688383413f4c832ebca5edd8d1c8850b